### PR TITLE
Fix displayed extension version.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,6 +17,6 @@
   "gettext-domain": "vertical-workspaces",
   "settings-schema": "org.gnome.shell.extensions.vertical-workspaces",
   "version-name": "46.1",
-  "version": 999
+  "version": 46.1
 }
 


### PR DESCRIPTION
Currently the Extensions App displays the version of this extension as "999" which is a bit confusing.

This commit changes it to be displayed as 46.1, to matches the extension version.

