### PR TITLE
Fix signal connection accumulation bug in _updateNewWindowConnection()

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -397,7 +397,7 @@ export default class VShell extends Extension.Extension {
                     _moveWinToMonitor();
                 }
             });
-        } else if ((nMonitors.length === 1 || !opt.FIX_NEW_WINDOW_MONITOR) && this._newWindowCreatedConId) {
+        } else if ((nMonitors === 1 || !opt.FIX_NEW_WINDOW_MONITOR) && this._newWindowCreatedConId) {
             global.display.disconnect(this._newWindowCreatedConId);
             this._newWindowCreatedConId = 0;
         }


### PR DESCRIPTION
## Problem Description

Gnome Shell 48 on Wayland occasionally freezes during workspace transitions, accompanied by the error: `JS ERROR: Error: No signal connection 1 found` in system logs.

The freeze appears to be triggered by signal handling issues, particularly when multiple overrides are applied and refreshed.

## Root Cause

Line 400 in `extension.js` contains a type mismatch bug:

```javascript
} else if ((nMonitors.length === 1 || \!opt.FIX_NEW_WINDOW_MONITOR) && this._newWindowCreatedConId) {
```

However, `nMonitors` on line 375 is an integer:

```javascript
const nMonitors = global.display.get_n_monitors();  // Returns: int
```

Integers don't have a `.length` property, so `nMonitors.length` is always `undefined`. This means the condition `undefined === 1` always evaluates to `false`, preventing the signal disconnection code from ever executing.

## Consequences

1. **Signal handler accumulation**: Each call to `_updateNewWindowConnection()` connects a new window-created signal handler without disconnecting old ones
2. **Orphaned handlers**: Old handlers remain registered and attached to stale objects
3. **Workspace transition freezes**: Gnome Shell's signal tracker detects these orphaned handlers during transitions and the Shell becomes unresponsive
4. **Memory leaks**: Disconnected objects stay in memory due to lingering signal references

## The Fix

Remove `.length` (one character change):

```javascript
} else if ((nMonitors === 1 || \!opt.FIX_NEW_WINDOW_MONITOR) && this._newWindowCreatedConId) {
```

This performs proper integer comparison, ensuring the disconnection code executes when:
- There's only one monitor, OR
- The `FIX_NEW_WINDOW_MONITOR` option is disabled

## Why This Fixes The Issue

With proper signal cleanup:
- Signal handlers are immediately disconnected when conditions change
- No accumulation of stale handlers
- Workspace transitions complete without triggering signal tracker errors
- Gnome Shell remains responsive

## Testing

This fix should resolve:
- Workspace switching freezes
- "No signal connection 1 found" errors in logs
- Improve overall stability of workspace transitions on multi-monitor setups

Possibly related to: #280