### PR TITLE
Remove bottom padding for panel menus

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -394,3 +394,7 @@ StButton#vhandle, StWidget .vhandle,
 .overview-tile:selected .source-badge-selected-only {
 	width: 16px;
 }
+
+.panel-menu {
+	margin: 0;
+}


### PR DESCRIPTION
With bottom panel option turned on notification list and other menus have big margin between itself and panel