### PR TITLE
GNOME 50 migration: clean up X11 code, add easeAsync helper

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -95,12 +95,13 @@ export default class VShell extends Extension.Extension {
         this._initModules();
 
         // prevent conflicts during startup
+        // GNOME 50 enables extensions after the startup animation begins,
+        // so we need to delay activation until the startup animation completes
         let skipStartup = Me.gSettings.get_boolean('delay-startup') ||
                 Me.Util.getEnabledExtensions('ubuntu-dock').length ||
                 Me.Util.getEnabledExtensions('dash-to-dock').length ||
                 Me.Util.getEnabledExtensions('dash2dock').length ||
                 Me.Util.getEnabledExtensions('dash-to-panel').length ||
-                // Temporary workaround – GNOME 50 enables extensions after the startup animation begins
                 Me.shellVersion >= 50;
         if (skipStartup && Main.layoutManager._startingUp) {
             this._startupConId = Main.layoutManager.connect('startup-complete', () => {

--- a/lib/appDisplay.js
+++ b/lib/appDisplay.js
@@ -215,10 +215,9 @@ export const AppDisplayModule = class {
                 this._appGridLayoutConId = global.settings.connect('changed::app-picker-layout', this._updateLayout.bind(this));
 
             // avoid resetting appDisplay before startup animation
-            // x11 shell restart skips startup animation
+            // x11 shell restart skips startup animation (Meta.is_restart() removed in GNOME 50)
             if (!Main.layoutManager._startingUp) {
                 this._repopulateAppDisplay();
-            // Meta.is_restart() is related to X11 session and is no longer supported since GNOME 50
             } else if (Meta.is_restart && Main.layoutManager._startingUp && Meta.is_restart()) {
                 Me.run.timeouts.delayRepopulation = GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
                     this._repopulateAppDisplay();

--- a/lib/layout.js
+++ b/lib/layout.js
@@ -443,16 +443,17 @@ const HotCornerCommon = {
 
     // A workaround for case when the GNOME Shell is unable to show overview in X11 session
     // if VirtualBox Machine window grabbed the keyboard
+    // GNOME 50 is Wayland-only, so this workaround is no longer needed
     _showOverviewWithDelay(state, customOverviewMode = false) {
+        if (Me.shellVersion >= 50)
+            return false;
+
         const focusWindow = global.display.get_focus_window();
-        // Meta.is_wayland_compositor() has benn removed since GNOME 50 which is Wayland only
         if (!Meta.is_wayland_compositor || Meta.is_wayland_compositor() || !focusWindow || !focusWindow.wm_class.includes('VirtualBox Machine'))
             return false;
 
         global.stage.set_key_focus(Main.panel);
-        // key focus doesn't take the effect immediately, we must wait for it
         Me.run.timeouts.releaseKeyboardTimeout = GLib.timeout_add(
-            // delay cannot be too short
             GLib.PRIORITY_DEFAULT, 200, () => {
                 Main.overview.show(state, customOverviewMode);
                 Me.run.timeouts.releaseKeyboardTimeout = 0;

--- a/lib/overviewBackground.js
+++ b/lib/overviewBackground.js
@@ -72,8 +72,9 @@ export const OverviewBackgroundModule = class {
 
         // update overview background wallpaper if enabled, but don't set it too early on the session startup
         // because it can crash wayland
-        // Meta.is_restart() is related to X11 session and is no longer supported since GNOME 50
-        if (!Main.layoutManager._startingUp || (Meta.is_restart && Meta.is_restart())) {
+        // Meta.is_restart() was related to X11 session and is no longer available since GNOME 50
+        const isRestart = Meta.is_restart && Meta.is_restart();
+        if (!Main.layoutManager._startingUp || isRestart) {
             this._backgroundController.setBackground();
         } else {
             // The "showing" signal is emitted during the session startup

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -23,7 +23,7 @@ export const Options = class Options {
         this._gsettings.delay();
         this.connect('changed', () => {
             if (this._writeTimeoutId)
-                GLib.Source.remove(this._writeTimeoutId);
+                GLib.source_remove(this._writeTimeoutId);
 
             this._writeTimeoutId = GLib.timeout_add(
                 GLib.PRIORITY_DEFAULT,

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,6 +31,21 @@ export function init(me) {
     _ = Me.gettext;
 }
 
+// GNOME 50 introduced easeAsync() which returns a Promise resolved on transition completion.
+// This helper provides a compatible wrapper for both old and new versions.
+// Usage: await easeActor(actor, { duration, mode, ... });
+export function easeAsync(actor, params) {
+    if (actor.easeAsync) {
+        return actor.easeAsync(params);
+    }
+    return new Promise(resolve => {
+        actor.ease({
+            ...params,
+            onStopped: () => resolve(),
+        });
+    });
+}
+
 export function cleanGlobals() {
     Me = null;
     _ = null;
@@ -694,8 +709,7 @@ export function getScrollDirection(event) {
     // first SMOOTH event returns 0 delta,
     //  so we need to always read event.direction
     //  since mouse without smooth scrolling provides exactly one SMOOTH event on one wheel rotation click
-    // on the other hand, under X11, one wheel rotation click sometimes doesn't send direction event, only several SMOOTH events
-    // so we also need to convert the delta to direction
+    // we also need to convert the delta to direction for smooth scrolling
     let direction = event.get_scroll_direction();
 
     if (direction !== Clutter.ScrollDirection.SMOOTH)
@@ -791,7 +805,7 @@ export function closeWorkspace(metaWorkspace, monitorIndex) {
 }
 
 // /////////////////////////////////////////////////////////////////////////////////////////////
-// Status dialog that appears during updating V-Shell configuration and blocks inputs
+// Status dialog that appears during V-Shell configuration update and blocks user input
 
 export const RestartMessage = GObject.registerClass({
     // Registered name should be unique


### PR DESCRIPTION
## Summary
- Skip X11 VirtualBox keyboard grab workaround on GNOME 50+ (Wayland-only)
- Simplify `Meta.is_restart()` guards with clearer variable extraction
- Add `easeAsync()` utility helper that uses GNOME 50's native async animation API with fallback for older versions
- Fix inconsistent `GLib.Source.remove()` → `GLib.source_remove()` in settings.js
- Update comments to reflect GNOME 50's Wayland-only status
- Improve startup delay documentation in extension.js

## Changes

### `lib/layout.js`
- Added `Me.shellVersion >= 50` early return in `_showOverviewWithDelay()` — the VirtualBox keyboard grab workaround is X11-only and GNOME 50 is Wayland-only

### `lib/overviewBackground.js`
- Extracted `Meta.is_restart` check into a clearer `isRestart` variable

### `lib/appDisplay.js`
- Consolidated comment about `Meta.is_restart()` removal in GNOME 50

### `lib/util.js`
- Added `easeAsync(actor, params)` helper that uses GNOME 50's native `easeAsync()` when available, falling back to `ease()` with `onStopped` callback on older versions
- Updated X11 scroll direction comment
- Improved `RestartMessage` class description

### `lib/settings.js`
- Fixed `GLib.Source.remove()` → `GLib.source_remove()` for consistency with the rest of the codebase

### `extension.js`
- Improved GNOME 50 startup delay comment to explain the rationale

## Test plan
- [ ] Verify extension loads without errors on GNOME 50
- [ ] Verify extension loads without errors on GNOME 49 (regression check)
- [ ] Verify overview show/hide works correctly
- [ ] Verify workspace switching works correctly
- [ ] Verify app grid opens correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)